### PR TITLE
Scripting Small Update

### DIFF
--- a/Engine/src/Engine/Scripting/ScriptSystem.cpp
+++ b/Engine/src/Engine/Scripting/ScriptSystem.cpp
@@ -36,12 +36,20 @@ namespace engine
     static std::string s_ProjDir = "../Scripting/Scripting.csproj";
     static std::string s_OutputDir = "../Sandbox/scripting";
     static std::string s_OutputFileName = "scripting";
+    static std::string s_OutputFilePath = s_OutputDir + "/" + s_OutputFileName + ".dll";
     static std::string s_ErrorsLogFile = "../Sandbox/scripting/errors.log";
     static std::string s_WarningsLogFile = "../Sandbox/scripting/warnings.log";
 
     /*-----------------------------------------------------------------------------*/
     /* Compiling                                                                   */
     /*-----------------------------------------------------------------------------*/
+
+    void ScriptSystem::Initialize()
+    {
+        if (!fs::exists(s_OutputFilePath))
+            return;
+        ScriptUtility::g_SystemInfo.Initialize(s_OutputFilePath.c_str(), s_ComponentMap);
+    }
 
     void ScriptSystem::Compile()
     {
@@ -115,7 +123,7 @@ namespace engine
 
         // load all system info for later use
         LOG_ENGINE_TRACE("Script Compiling Successful");
-        ScriptUtility::g_SystemInfo.Initialize((s_OutputDir + "/" + s_OutputFileName + ".dll").c_str(), s_ComponentMap);
+        ScriptUtility::g_SystemInfo.Initialize(s_OutputFilePath.c_str(), s_ComponentMap);
 
         ScriptSystem* ss = SceneManager::GetActiveWorld().TryGetSystem<ScriptSystem>();
         if (ss != nullptr)

--- a/Engine/src/Engine/Scripting/ScriptSystem.cpp
+++ b/Engine/src/Engine/Scripting/ScriptSystem.cpp
@@ -161,16 +161,6 @@ namespace engine
         for (auto& scripting : m_ECS_Manager.GetComponentDenseArray<Scripting>())
         {
             scripting.SetUpPlay();
-            for (auto const& component : ScriptUtility::g_SystemInfo.componentMap)
-            {
-                if (component.second.Has(scripting.GetEntity()))
-                {
-                    MonoClass* _class = mono_type_get_class(component.first);
-                    const char* name_space = mono_class_get_namespace(_class);
-                    const char* name = mono_class_get_name(_class);
-                    scripting.AddComponentInterface(name_space, name);
-                }
-            }
         }
         for (auto& scripting : m_ECS_Manager.GetComponentDenseArray<Scripting>())
         {

--- a/Engine/src/Engine/Scripting/ScriptSystem.h
+++ b/Engine/src/Engine/Scripting/ScriptSystem.h
@@ -36,6 +36,12 @@ namespace engine
         /*-----------------------------------------------------------------------------*/
 
         /*********************************************************************************//*!
+        \brief      loads the currently compiled scripts, if any. This should be called only
+                    after registering all components into the ScriptSystem
+        *//**********************************************************************************/
+        static void Initialize();
+
+        /*********************************************************************************//*!
         \brief      executes the required actions to compile all user made scripts during runtime
         *//**********************************************************************************/
         static void Compile();

--- a/Engine/src/Engine/Scripting/Scripting.cpp
+++ b/Engine/src/Engine/Scripting/Scripting.cpp
@@ -432,8 +432,6 @@ namespace engine
     Component& Scripting::CopyComponent(Component const& comp)
     {
         auto& scripting = reinterpret_cast<Scripting const&>(comp);
-        componentList = scripting.componentList;
-        scriptList = scripting.scriptList;
         scriptInfoMap = scripting.scriptInfoMap;
         return *this;
     }

--- a/Engine/src/Engine/Scripting/Scripting.cpp
+++ b/Engine/src/Engine/Scripting/Scripting.cpp
@@ -770,26 +770,7 @@ namespace engine
             MonoMethod* stringMethod = mono_class_get_method_from_name(mono_get_exception_class(), "ToString", 0);
             MonoString* excString = (MonoString*)mono_runtime_invoke(stringMethod, exception, NULL, NULL);
             LOG_CRITICAL(mono_string_to_utf8(excString));
-            //MonoProperty* excMsgProperty = mono_class_get_property_from_name(mono_get_exception_class(), "Message");
-            //MonoString* excMsg = (MonoString*)mono_property_get_value(excMsgProperty, exception, NULL, NULL);
-            //LOG_CRITICAL(mono_string_to_utf8(excMsg));
-            // mono_print_unhandled_exception(exception);
         }
-        //__try
-        //{
-        //    mono_runtime_invoke(method, script, NULL, (MonoObject**)&exception);
-        //}
-        //__finally
-        //{
-        //    //std::cout << "SOMETHING" << std::endl;
-        //    if (exception)
-        //    {
-        //        MonoProperty* excMsgProperty = mono_class_get_property_from_name(mono_get_exception_class(), "Message");
-        //        MonoString* excMsg = (MonoString*)mono_property_get_value(excMsgProperty, exception, NULL, NULL);
-        //        LOG_ERROR(mono_string_to_utf8(excMsg));
-        //        mono_print_unhandled_exception(exception);
-        //    }
-        //}
     }
 
     void Scripting::InvokeFunctionAll(const char* functionName, int paramCount, void** params)

--- a/Engine/src/Engine/Scripting/Scripting.cpp
+++ b/Engine/src/Engine/Scripting/Scripting.cpp
@@ -419,6 +419,11 @@ namespace engine
 
     }
 
+    Scripting::Scripting(Scripting const& ref) : Component{ ref.GetEntity(), ref.IsActive() }, gameObjPtr{ 0 }, scriptInfoMap{ ref.scriptInfoMap }
+    {
+
+    }
+
     Scripting::~Scripting()
     {
         StopPlay();
@@ -684,6 +689,18 @@ namespace engine
         // set GameObject's transform
         MonoClassField* transformField = mono_class_get_field_from_name(_class, "m_Transform");
         mono_field_set_value(gameObject, transformField, transform);
+
+        // add all other Components
+        for (auto const& component : ScriptUtility::g_SystemInfo.componentMap)
+        {
+            if (component.second.Has(GetEntity()))
+            {
+                MonoClass* _class = mono_type_get_class(component.first);
+                const char* name_space = mono_class_get_namespace(_class);
+                const char* name = mono_class_get_name(_class);
+                AddComponentInterface(name_space, name);
+            }
+        }
 
         // create all script instances
         for (auto const& scriptInfo : scriptInfoMap)

--- a/Engine/src/Engine/Scripting/Scripting.h
+++ b/Engine/src/Engine/Scripting/Scripting.h
@@ -28,8 +28,8 @@ namespace engine
         /* Constructors and Destructors                                                */
         /*-----------------------------------------------------------------------------*/
         Scripting() = delete;
-        Scripting(Scripting const&) = default;
-        Scripting(Scripting&&) = default;
+        Scripting(Scripting const&);
+        //Scripting(Scripting&&) = default;
 
         /****************************************************************************//*!
          @brief     Copies the relevant data of scripting component while retaining

--- a/Sandbox/src/ScriptingLayer.h
+++ b/Sandbox/src/ScriptingLayer.h
@@ -13,6 +13,9 @@ public:
         engine::ScriptSystem::RegisterComponent<engine::Rigidbody2D>("Ouroboros.Rigidbody2D");
         engine::ScriptSystem::RegisterComponent<engine::Collider2D>("Ouroboros.Collider2D");
         engine::ScriptSystem::RegisterComponent<engine::CircleCollider2D>("Ouroboros.CircleCollider2D");
+
+        // load scripting.dll
+        engine::ScriptSystem::Initialize();
     }
 
     ~ScriptingLayer()

--- a/Sandbox/src/TestLayers/ScriptingTestLayer.h
+++ b/Sandbox/src/TestLayers/ScriptingTestLayer.h
@@ -45,8 +45,6 @@ public:
         auto& ss = m_scene.GetWorld().RegisterSystem<engine::ScriptSystem>();
         auto& ps = m_scene.GetWorld().RegisterSystem<engine::PhysicsSystem>();
 
-        engine::ScriptSystem::Compile();
-
         // Player
         {
             engine::GameObject obj = CreateGameObject();


### PR DESCRIPTION
- shifted some code from Script System StartPlay to Scripting SetUpPlay (makes more sense and may make some future stuff easier)
- added loading scripting.dll on start up if it exists without recompiling, so you dont have to compile keep recompiling at the start
- Scripting copy constructor and CopyComponent changed to only copy script info, all other stuff it should generate on its own if needed