### PR TITLE
Physics collision

### DIFF
--- a/Engine/src/Engine/ECS/Component.h
+++ b/Engine/src/Engine/ECS/Component.h
@@ -24,6 +24,21 @@ namespace engine
 
         void SetActive(bool _active) { m_active = _active; }
 
+        template<typename Derived, typename T2 = engine::WorldManager, typename... Args>
+        std::enable_if_t<std::is_base_of_v<Component, Derived>, Derived& >
+        AddComponent(Args... args) const
+        {
+            return T2::GetActiveWorld().EmplaceComponent<Derived>(m_entity, true, args...);
+        }
+        
+        template<typename NotDerived, typename T2 = engine::WorldManager, typename... Args>
+        std::enable_if_t<!std::is_base_of_v<Component, NotDerived>, NotDerived& >
+        AddComponent(Args... args) const
+        {
+            return T2::GetActiveWorld().EmplaceComponent<NotDerived>(m_entity, args...);
+        }
+
+
         template<typename T, typename T2 = engine::WorldManager>
         T& GetComponent() const
         {
@@ -40,6 +55,21 @@ namespace engine
         bool HasComponent() const
         {
             return T2::GetActiveWorld().HasComponent<T>(m_entity);
+        }
+
+        template<typename T, typename T2 = engine::WorldManager, typename... Args>
+        T& EnsureComponent(Args... args) const
+        {
+            return HasComponent<T>() ? GetComponent<T>() : AddComponent<T>(args...);
+        }
+
+        template<typename T, typename T2 = engine::WorldManager>
+        bool TryRemoveComponent() const
+        {
+            if (!T2::GetActiveWorld().HasComponent<T>(m_entity)) return false;
+            
+            T2::GetActiveWorld().RemoveComponent<T>(m_entity);
+            return true;
         }
 
         RTTR_ENABLE()

--- a/Engine/src/Engine/ECS/Component.h
+++ b/Engine/src/Engine/ECS/Component.h
@@ -5,6 +5,18 @@
 
 namespace engine
 {
+    //Convinience macro to be put in anything that inherits from component
+    #define DEFAULT_COMPONENT_CONSTRUCTORS(component)\
+    component()                             = delete;\
+    component(component const&)             = default;\
+    component(component&&)                  = default;\
+    component& operator=(component const&)  = default;\
+    component& operator=(component&&)       = default;
+
+    #define DEFAULT_COMPONENT(component)\
+    DEFAULT_COMPONENT_CONSTRUCTORS(component);\
+    virtual ~component()                    = default;
+
     class WorldManager;
     class Component
     {
@@ -72,7 +84,15 @@ namespace engine
             return true;
         }
 
-        RTTR_ENABLE()
+        template<typename T, typename T2 = engine::WorldManager>
+        void EnsureRemove() const
+        {
+            if (!T2::GetActiveWorld().HasComponent<T>(m_entity)) return;
+
+            T2::GetActiveWorld().RemoveComponent<T>(m_entity);
+        }
+        
+        RTTR_ENABLE();
 
     protected:
         Entity m_entity;

--- a/Engine/src/Engine/PhysicsCollision/Algorithms/PhysicsManifold.cpp
+++ b/Engine/src/Engine/PhysicsCollision/Algorithms/PhysicsManifold.cpp
@@ -85,7 +85,7 @@ namespace engine
         if (closest == dirVec)
         {
             inside = true;
-            if (oom::abs(dirVec.x) > oom::abs(dirVec.y))
+            if (oom::abs(dirVec.x) < oom::abs(dirVec.y))
             {
                 if (closest.x > 0) closest.x = x_extent;
                 else closest.x = -x_extent;
@@ -97,8 +97,11 @@ namespace engine
             }
         }
 
-        result.Normal = oom::normalize(boxCenter - closest);
-        result.PenetrationDepth = circleA.radius - oom::length(boxCenter - closest);
+        oom::vec2 normal = dirVec - closest;
+        float d = oom::length(normal);
+
+        result.Normal = oom::normalize(normal);
+        result.PenetrationDepth = circleA.radius - d;
 
         if (inside)
         {

--- a/Engine/src/Engine/PhysicsCollision/Algorithms/PhysicsManifold.cpp
+++ b/Engine/src/Engine/PhysicsCollision/Algorithms/PhysicsManifold.cpp
@@ -31,8 +31,6 @@ namespace engine
         auto circleA = circle.GetGlobalBounds();
         auto circleB = circle2.GetGlobalBounds();
 
-        //if (!Collision::Test2DCircleCircle(circleA, circleB)) return result;
-
         vec2 dirVec = circleB.center - circleA.center;
         // find distance
         float dist = oom::length(dirVec);
@@ -65,17 +63,140 @@ namespace engine
 
     Manifold2D PhysicsManifold::GenerateManifold2D(CircleCollider2D const& circle, BoxCollider2D const& aabb)
     {
-        return Manifold2D{};
+        Manifold2D result{};
+
+        // Need to update proeprly
+
+        auto circleA = circle.GetGlobalBounds();
+        auto boxB = aabb.GetGlobalBounds();
+
+        auto boxCenter = (boxB.max + boxB.min) * 0.5f;
+        vec2 dirVec = boxCenter - circleA.center;
+        
+        auto closest = dirVec;
+        float x_extent = (boxB.max.x - boxB.min.x) * 0.5f;
+        float y_extent = (boxB.max.y - boxB.min.y) * 0.5f;
+
+        closest.x = std::clamp(closest.x, -x_extent, x_extent);
+        closest.y = std::clamp(closest.y, -y_extent, y_extent);
+
+        bool inside = false;
+
+        if (closest == dirVec)
+        {
+            inside = true;
+            if (oom::abs(dirVec.x) > oom::abs(dirVec.y))
+            {
+                if (closest.x > 0) closest.x = x_extent;
+                else closest.x = -x_extent;
+            }
+            else
+            {
+                if (closest.y > 0) closest.y = y_extent;
+                else closest.y = -y_extent;
+            }
+        }
+
+        result.Normal = oom::normalize(boxCenter - closest);
+        result.PenetrationDepth = circleA.radius - oom::length(boxCenter - closest);
+
+        if (inside)
+        {
+            result.Normal *= -1;
+        }
+
+        result.HasCollision = true;
+
+        return result;
     }
 
     Manifold2D PhysicsManifold::GenerateManifold2D(BoxCollider2D const& aabb, CircleCollider2D const& circle)
     {
-        return Manifold2D{};
+        Manifold2D result{};
+
+        auto boxA = aabb.GetGlobalBounds();
+        auto circleB = circle.GetGlobalBounds();
+
+        auto boxCenter = (boxA.max + boxA.min) * 0.5f;
+        vec2 dirVec = circleB.center - boxCenter;
+
+        auto closest = dirVec;
+        float x_extent = (boxA.max.x - boxA.min.x) * 0.5f;
+        float y_extent = (boxA.max.y - boxA.min.y) * 0.5f;
+
+        closest.x = std::clamp(closest.x, -x_extent, x_extent);
+        closest.y = std::clamp(closest.y, -y_extent, y_extent);
+
+        bool inside = false;
+
+        if (closest == dirVec)
+        {
+            inside = true;
+            if (oom::abs(dirVec.x) > oom::abs(dirVec.y))
+            {
+                if (closest.x > 0) closest.x = x_extent;
+                else closest.x = -x_extent;
+            }
+            else
+            {
+                if (closest.y > 0) closest.y = y_extent;
+                else closest.y = -y_extent;
+            }
+        }
+
+        oom::vec2 normal = dirVec - closest;
+        float d = oom::length(normal);
+
+        result.Normal = oom::normalize(normal);//oom::normalize(closest - circleB.center);//oom::normalize(boxCenter - closest);
+        result.PenetrationDepth = circleB.radius - d;
+
+        if (inside)
+        {
+            result.Normal *= -1;
+        }
+
+        result.HasCollision = true;
+
+        return result;
     }
 
     Manifold2D PhysicsManifold::GenerateManifold2D(BoxCollider2D const& aabb, BoxCollider2D const& aabb2)
     {
-        return Manifold2D{};
+        Manifold2D result{};
+
+        auto boxA = aabb.GetGlobalBounds();
+        auto boxB = aabb2.GetGlobalBounds();
+
+        oom::vec2 n = (boxB.min + boxB.max) * 0.5f - (boxA.min + boxA.max) * 0.5f;
+
+        float ax_extent = (boxA.max.x - boxA.min.x) * 0.5f;
+        float bx_extent = (boxB.max.x - boxB.min.x) * 0.5f;
+
+        float x_overlap = ax_extent + bx_extent - std::abs(n.x);
+
+        //assumes overlap
+        float ay_extent = (boxA.max.y - boxA.min.y) * 0.5f;
+        float by_extent = (boxB.max.y - boxB.min.y) * 0.5f;
+
+        float y_overlap = ay_extent + by_extent - std::abs(n.y);
+
+        // find axis of least penetration
+        if (x_overlap < y_overlap)
+        {
+            if (n.x < 0) result.Normal = { -1, 0 };
+            else result.Normal = { 1, 0 };
+            result.PenetrationDepth = x_overlap;
+        }
+        else
+        {
+            if (n.y < 0) result.Normal = { 0, -1 };
+            else result.Normal = { 0, 1 };
+            result.PenetrationDepth = y_overlap;
+        }
+
+        result.HasCollision = true;
+
+        return result;
     }
 
 }

--- a/Engine/src/Engine/PhysicsCollision/ColliderCore.cpp
+++ b/Engine/src/Engine/PhysicsCollision/ColliderCore.cpp
@@ -66,24 +66,18 @@ namespace engine
     void Collider2D::SetNarrowPhaseCollider(ColliderType narrowPhaseCollider)
     {
         if (m_narrowPhaseCollider == narrowPhaseCollider) return;
-
-        /*switch (m_narrowPhaseCollider)
+        //remove to achieve one collider per objet
+        switch (m_narrowPhaseCollider)
         {
-        case ColliderType::BOX: RemoveComponent<BoxCollider2D>();
+        case ColliderType::BOX: TryRemoveComponent<BoxCollider2D>();
             break;
-        case ColliderType::CIRCLE: RemoveComponent<CircleCollider2D>();
+        case ColliderType::CIRCLE: TryRemoveComponent<CircleCollider2D>();
             break;
-        };*/
+        };
 
         m_narrowPhaseCollider = narrowPhaseCollider;
-
-        /*switch (m_narrowPhaseCollider)
-        {
-        case ColliderType::BOX: AddComponent<BoxCollider2D>();
-            break;
-        case ColliderType::CIRCLE: AddComponent<CircleCollider2D>();
-            break;
-        };*/
+        
+        // no need to add because the interface to add is via the derived colliders.
     }
 
     void Collider2D::Update()

--- a/Engine/src/Engine/PhysicsCollision/ColliderCore.h
+++ b/Engine/src/Engine/PhysicsCollision/ColliderCore.h
@@ -27,6 +27,37 @@ namespace engine
         CIRCLE,
         BOX
     };
+    
+    class CollisionInfo : public Component
+    {
+    public:
+        /*-----------------------------------------------------------------------------*/
+        /* Constructors and Destructors                                                */
+        /*-----------------------------------------------------------------------------*/
+        DEFAULT_COMPONENT(CollisionInfo);
+
+        explicit CollisionInfo(Entity entity, bool active = true);
+
+        /*-----------------------------------------------------------------------------*/
+        /* Supported Event Callbacks                                                   */
+        /*-----------------------------------------------------------------------------*/
+        EventCallback<Manifold2D> OnCollisionEnter;
+        EventCallback<Manifold2D> OnCollisionStay;
+        EventCallback<Manifold2D> OnCollisionExit;
+
+        EventCallback<Collider2D> OnTriggerEnter;
+        EventCallback<Collider2D> OnTriggerStay;
+        EventCallback<Collider2D> OnTriggerExit;
+    
+    private:
+        friend class PhysicsSystem;
+        void Update();
+
+        std::unordered_map<Entity, Manifold2D> m_previousCollisions{};
+        std::unordered_map<Entity, Collider2D> m_previousTriggers{};
+        std::unordered_map<Entity, Manifold2D> m_collisions{};
+        std::unordered_map<Entity, Collider2D> m_triggers{};
+    };
 
     class Collider2D : public Component
     {
@@ -39,44 +70,23 @@ namespace engine
         ColliderType m_broadphaseCollider   = ColliderType::BOX;
         ColliderType m_narrowPhaseCollider  = ColliderType::CIRCLE;
 
-        bool m_previous = false, m_current = false;
-        std::vector<Manifold2D> m_collisions{};
-        std::vector<Collider2D> m_triggers{};
-        friend class PhysicsSystem;
-        void Update();
+        //std::unordered_map<Entity, Manifold2D> m_previousCollisions{};
+        //std::unordered_map<Entity, Collider2D> m_previousTriggers{};
+        //std::unordered_map<Entity, Manifold2D> m_collisions{};
+        //std::unordered_map<Entity, Collider2D> m_triggers{};
+
+        /*friend class PhysicsSystem;
+        void Update();*/
 
     public:
         bool IsTrigger = false; // for now the entire object is either a trigger or collider
-        /*vec2 Offset = { 0, 0 };*/
 
         /*-----------------------------------------------------------------------------*/
         /* Constructors and Destructors                                                */
         /*-----------------------------------------------------------------------------*/
-        Collider2D()                            = delete;
-        Collider2D(Collider2D const&)           = default;
-        Collider2D(Collider2D &&)               = default;
-        Collider2D& operator=(Collider2D const&)= default;
-        Collider2D& operator=(Collider2D &&)    = default;
-        virtual ~Collider2D()                   = default;
-
         explicit Collider2D(Entity entity, bool active = true);
-
-        /*-----------------------------------------------------------------------------*/
-        /* Supported Event Callbacks                                                   */
-        /*-----------------------------------------------------------------------------*/
-        
-        EventCallback<std::vector<Manifold2D>> OnCollisionEnter;
-        EventCallback<std::vector<Manifold2D>> OnCollisionStay;
-        EventCallback<std::vector<Manifold2D>> OnCollisionExit;
-
-        EventCallback<std::vector<Collider2D>> OnTriggerEnter;
-        EventCallback<std::vector<Collider2D>> OnTriggerStay;
-        EventCallback<std::vector<Collider2D>> OnTriggerExit;
-        
-
-        /*-----------------------------------------------------------------------------*/
-        /* Supported Event Callbacks                                                   */
-        /*-----------------------------------------------------------------------------*/
+        virtual ~Collider2D();
+        DEFAULT_COMPONENT_CONSTRUCTORS(Collider2D);
 
         // third attempt : double components - function map collision
         ColliderType GetBroadPhaseCollider() const { return m_broadphaseCollider; }

--- a/Engine/src/Engine/PhysicsCollision/Colliders.cpp
+++ b/Engine/src/Engine/PhysicsCollision/Colliders.cpp
@@ -14,6 +14,8 @@ Technology is prohibited.
 #include "pch.h"
 #include "Colliders.h"
 
+#include "Engine/ECS/GameObject.h"
+
 #include "Engine/ECS/WorldManager.h"
 #include "ColliderCore.h"
 
@@ -39,7 +41,9 @@ namespace engine
         : Component{ entity, active }
         /*, IsTrigger{ false }*/
         , Offset{ 0.f, 0.f }
-    {}
+    {
+        EnsureComponent<Collider2D>();
+    }
 
     oom::vec2 ColliderBase2D::WorldPosition() const
     {
@@ -57,6 +61,7 @@ namespace engine
         , Bounds{ {-0.5f, -0.5f}, { 0.5f, 0.5f } }
         , Size{ 1.f, 1.f }
     {
+        GetComponent<Collider2D>().SetNarrowPhaseCollider(engine::ColliderType::BOX);
     };
 
     AABB2D BoxCollider2D::GetGlobalBounds() const
@@ -75,7 +80,9 @@ namespace engine
         : ColliderBase2D{ entity, active }
         , Bounds{ { 0.f, 0.f }, 1.f }
         , Radius{ 0.5f }
-    {};
+    {
+        GetComponent<Collider2D>().SetNarrowPhaseCollider(engine::ColliderType::CIRCLE);
+    };
 
     Circle CircleCollider2D::GetGlobalBounds() const
     {

--- a/Engine/src/Engine/PhysicsCollision/Colliders.cpp
+++ b/Engine/src/Engine/PhysicsCollision/Colliders.cpp
@@ -45,12 +45,17 @@ namespace engine
         EnsureComponent<Collider2D>();
     }
 
-    oom::vec2 ColliderBase2D::WorldPosition() const
+    ColliderBase2D::~ColliderBase2D()
+    {
+        //EnsureRemove<Collider2D>();
+    }
+
+    vec2 ColliderBase2D::WorldPosition() const
     {
         return GetComponent<Transform3D>().GetGlobalPosition();
     }
 
-    oom::vec2 ColliderBase2D::WorldScale() const
+    vec2 ColliderBase2D::WorldScale() const
     {
         return GetComponent<Transform3D>().GetGlobalScale();
     }

--- a/Engine/src/Engine/PhysicsCollision/Colliders.h
+++ b/Engine/src/Engine/PhysicsCollision/Colliders.h
@@ -30,14 +30,9 @@ namespace engine
         oom::vec2 WorldPosition() const;
 
         explicit ColliderBase2D(Entity entity, bool active = true);
+        virtual ~ColliderBase2D();
 
-        ColliderBase2D()                                    = delete;
-        ColliderBase2D(ColliderBase2D const&)               = default;
-        ColliderBase2D(ColliderBase2D&&)                    = default;
-        ColliderBase2D& operator=(ColliderBase2D const&)    = default;
-        ColliderBase2D& operator=(ColliderBase2D&&)         = default;
-        virtual ~ColliderBase2D()                           = default;
-
+        DEFAULT_COMPONENT_CONSTRUCTORS(ColliderBase2D);
     };
     
     struct CircleCollider2D : public ColliderBase2D
@@ -48,13 +43,7 @@ namespace engine
         Circle GetGlobalBounds() const;
 
         explicit CircleCollider2D(Entity entity, bool active = true);
-
-        CircleCollider2D()                                      = delete;
-        CircleCollider2D(CircleCollider2D const&)               = default;
-        CircleCollider2D(CircleCollider2D&&)                    = default;
-        CircleCollider2D& operator=(CircleCollider2D const&)    = default;
-        CircleCollider2D& operator=(CircleCollider2D&&)         = default;
-        virtual ~CircleCollider2D()                             = default;
+        DEFAULT_COMPONENT(CircleCollider2D);
 
         RTTR_ENABLE();
     };
@@ -67,15 +56,24 @@ namespace engine
         AABB2D GetGlobalBounds() const;
 
         explicit BoxCollider2D(Entity entity, bool active = true);
-
-        BoxCollider2D()                                 = delete;
-        BoxCollider2D(BoxCollider2D const&)             = default;
-        BoxCollider2D(BoxCollider2D&&)                  = default;
-        BoxCollider2D& operator=(BoxCollider2D const&)  = default;
-        BoxCollider2D& operator=(BoxCollider2D&&)       = default;
-        virtual ~BoxCollider2D()                        = default;
+        DEFAULT_COMPONENT(BoxCollider2D);
 
         RTTR_ENABLE();
     };
 
+    /*struct PlaneCollider2D 
+    {
+        AABB2D GetGlobalBounds() const;
+
+        explicit BoxCollider2D(Entity entity, bool active = true);
+
+        BoxCollider2D() = delete;
+        BoxCollider2D(BoxCollider2D const&) = default;
+        BoxCollider2D(BoxCollider2D&&) = default;
+        BoxCollider2D& operator=(BoxCollider2D const&) = default;
+        BoxCollider2D& operator=(BoxCollider2D&&) = default;
+        virtual ~BoxCollider2D() = default;
+
+        RTTR_ENABLE();
+    };*/
 }

--- a/Engine/src/Engine/PhysicsCollision/PhysicsSystem.h
+++ b/Engine/src/Engine/PhysicsCollision/PhysicsSystem.h
@@ -77,6 +77,9 @@ namespace engine
 
         double m_accumulator;
 
+        std::vector<Collider2D> m_narrowPhaseTriggers;
+        std::vector<Collider2D> m_narrowPhaseColliders;
+
         std::vector<Manifold2D> m_collisions;
         std::vector<Manifold2D> m_triggers;
         std::vector<Solver*> m_solvers;

--- a/Engine/src/Engine/PhysicsCollision/PhysicsUtils.cpp
+++ b/Engine/src/Engine/PhysicsCollision/PhysicsUtils.cpp
@@ -45,66 +45,11 @@ namespace engine
     bool PhysicsUtils::TestCollision2D(Collider2D const& first, Collider2D const& second)
     {
         return m_collisionMap[std::make_pair(first.GetNarrowPhaseCollider(), second.GetNarrowPhaseCollider())](first, second);
-
-        /*switch (first.GetNarrowPhaseCollider())
-        {
-        case ColliderType::CIRCLE:
-        {
-            auto const& circle = first.GetComponent<CircleCollider2D>().GetGlobalBounds();
-
-            switch (second.GetNarrowPhaseCollider())
-            {
-            case ColliderType::CIRCLE:
-                return Collision::Test2DCircleCircle(circle, second.GetComponent<CircleCollider2D>().GetGlobalBounds());
-
-
-            case ColliderType::BOX:
-                return Collision::Test2DCircleAABB(circle, second.GetComponent<BoxCollider2D>().GetGlobalBounds());
-            }
-        }
-
-        case ColliderType::BOX:
-        {
-            auto const& box = first.GetComponent<BoxCollider2D>().GetGlobalBounds();
-            switch (second.GetNarrowPhaseCollider())
-            {
-            case ColliderType::BOX:
-                return Collision::Test2DAABBAABB(box, second.GetComponent<BoxCollider2D>().GetGlobalBounds());
-
-
-            case ColliderType::CIRCLE:
-                return Collision::Test2DCircleAABB(second.GetComponent<CircleCollider2D>().GetGlobalBounds(), box);
-
-            }
-        }
-        }*/
     }
 
     Manifold2D PhysicsUtils::GenerateManifold2D(Collider2D const& first, Collider2D const& second)
     {
         return m_manifoldMap[std::make_pair(first.GetNarrowPhaseCollider(), second.GetNarrowPhaseCollider())](first, second);
-
-        //switch (first.GetNarrowPhaseCollider())
-        //{
-        //case ColliderType::CIRCLE:
-        //    switch (second.GetNarrowPhaseCollider())
-        //    {
-        //    case ColliderType::CIRCLE:
-        //        return PhysicsManifold::Test2DCollision(first.GetComponent<CircleCollider2D>(), second.GetComponent<CircleCollider2D>());
-
-        //    case ColliderType::BOX:
-        //        return PhysicsManifold::Test2DCollision(first.GetComponent<CircleCollider2D>(), second.GetComponent<BoxCollider2D>());
-        //    }
-        //case ColliderType::BOX:
-        //    switch (second.GetNarrowPhaseCollider())
-        //    {
-        //    case ColliderType::CIRCLE:
-        //        return PhysicsManifold::Test2DCollision(first.GetComponent<BoxCollider2D>(), second.GetComponent<CircleCollider2D>());
-
-        //    case ColliderType::BOX:
-        //        return PhysicsManifold::Test2DCollision(first.GetComponent<BoxCollider2D>(), second.GetComponent<BoxCollider2D>());
-        //    }
-        //}
     }
 
 

--- a/Engine/src/Engine/PhysicsCollision/PhysicsUtils.h
+++ b/Engine/src/Engine/PhysicsCollision/PhysicsUtils.h
@@ -23,6 +23,8 @@ namespace engine
         using StaticTriggerCollisionFnc = bool((*)(Collider2D, Collider2D));
         using GenerateManifoldFnc = Manifold2D((*)(Collider2D, Collider2D));
 
+        //static void ResolveStaticCollisions(Collider2D const& first, Collider2D const& second);
+
         // non physics - triggers only test
         static bool TestCollision2D(Collider2D const& first, Collider2D const& second);
 
@@ -30,6 +32,13 @@ namespace engine
         static Manifold2D GenerateManifold2D(Collider2D const& first, Collider2D const& second);
 
     private:
+
+        //Collision Maps
+        //static std::map<Entity, std::map<Entity, Collider2D>> S_PreviousTriggers;
+        //static std::map<Entity, std::map<Entity, Collider2D>> S_CurrentTriggers;
+        //static std::map<Entity, std::map<Entity, Manifold2D>> S_PreviousCollisions;
+        //static std::map<Entity, std::map<Entity, Manifold2D>> S_CurrentCollisions;
+
         //Maps
         static std::map<CombinationKey, StaticTriggerCollisionFnc> m_collisionMap;
         static std::map<CombinationKey, GenerateManifoldFnc> m_manifoldMap;

--- a/Sandbox/src/Editor/InspectorView.cpp
+++ b/Sandbox/src/Editor/InspectorView.cpp
@@ -201,6 +201,8 @@ void InspectorView::ComponentAddButton(float x ,float y)
 			AddComponent |= ComponentAddOptions<engine::Sprite2D>(go);
 			AddComponent |= ScriptAddOptions(go);
 			AddComponent |= ComponentAddOptions<engine::Rigidbody2D>(go);
+			AddComponent |= ComponentAddOptions<engine::BoxCollider2D>(go);
+			AddComponent |= ComponentAddOptions<engine::CircleCollider2D>(go);
 		}
 		ImGui::EndChild();
 

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
@@ -15,141 +15,421 @@ Technology is prohibited.
 
 PhysicsTestLayer::PhysicsTestLayer()
     : SceneBaseLayer{ "PhysicsTestLayer" }
-    , m_upperbounds{ 500,  200 }
-    , m_lowerbounds{ -500, -200 }
+    , m_upperbounds{ 150,  150 }
+    , m_lowerbounds{ -150, -150 }
     , m_spawnPosController { 0, 0, 0 }
-    , m_spawnPosOther { 75, 0, 0 }
+    , m_initDiff{ 40 }
     , m_controller{ }
-    , m_other{ }
 {
 }
 
 void PhysicsTestLayer::Init()
 {
-    auto ogreHandle = engine::AssetManager::ImportAsset("../Engine/assets/images/ogre.png");
-    auto tex = engine::AssetManager::GetAsset<engine::Texture>(ogreHandle);
-
-    DefaultCamera().SetOrthographic(1000);
     auto& rs = GetWorld()->RegisterSystem<engine::Renderer2DSystem>(DefaultCamera());
     auto& ps = GetWorld()->RegisterSystem<engine::PhysicsSystem>();
 
+    // Controller : 10 kg box
     {
         m_controller = CreateGameObject();
-        m_controller.Transform().Scale() = { 50.f, 50.f, 1.0f };
+        m_controller.Name() = "Controller is a 10KG box";
+        m_controller.Transform().Scale() = { 10.f, 10.f, 1.0f };
         m_controller.Transform().Position() = m_spawnPosController;
-        m_controller.AddComponent<engine::Sprite2D>();
+        m_controller.AddComponent<engine::ColliderDebugDraw>();
 
         auto& pc = m_controller.AddComponent<engine::Rigidbody2D>();
-        pc.SetMass(1.f);
+        pc.SetMass(10.f);
         pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_controller);
 
         m_controller.AddComponent<engine::BoxCollider2D>();
-        auto& c = m_controller.GetComponent<engine::Collider2D>();
+        auto& c = m_controller.GetComponent<engine::CollisionInfo>();
         //c.IsTrigger = true;
         
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
         //m_controller.AddComponent<engine::BoxCollider2D>();
 
         c.OnTriggerEnter +=
-            [=](auto const& manifolds) 
+            [=](auto const& collider) 
         { 
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
-            LOG_TRACE("ON TRIGGER ENTER");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
         };
         c.OnTriggerStay +=
-            [=](auto const& manifolds)
+            [=](auto const& collider)
         {
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
-            LOG_TRACE("ON TRIGGER STAY");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
         };
         c.OnTriggerExit +=
-            [=](auto const& manifolds)
+            [=](auto const& collider)
         {
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
-            LOG_TRACE("ON TRIGGER EXIT");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
         };
         c.OnCollisionEnter +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
-            LOG_TRACE("ON COLLISION ENTER");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
         };
         c.OnCollisionStay +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
-            LOG_TRACE("ON COLLISION STAY");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
         };
         c.OnCollisionExit +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
-            LOG_TRACE("ON COLLISION EXIT");
+            m_controller.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
         };
 
         
     }
-
+    
+    // First Item : 100 kg Physics box
     {
-        m_other = CreateGameObject();
-        m_other.Transform().Position() = m_spawnPosOther;
-        m_other.Transform().Scale() = { 50.f, 50.f, 1.0f };
-        m_other.AddComponent<engine::Sprite2D>();
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "100kg box";
+        m_other.Transform().Position().x = m_initDiff;
+        m_other.Transform().Scale() = { 20.f, 20.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
         
         auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
-        pc.SetMass(1000.f);
+        pc.SetMass(100.f);
         pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_other);
 
         m_other.AddComponent<engine::BoxCollider2D>();
-        auto& c = m_other.GetComponent<engine::Collider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
         //c.IsTrigger = true;
+
         c.OnTriggerEnter +=
-            [=](auto const& manifolds)
+            [=](auto const& collider)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 0, 1 });
-            LOG_TRACE("ON TRIGGER ENTER");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
         };
         c.OnTriggerStay +=
-            [=](auto const& manifolds)
+            [=](auto const& collider)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 0, 1 });
-            LOG_TRACE("ON TRIGGER STAY");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
         };
         c.OnTriggerExit +=
-            [=](auto const& manifolds)
+            [=](auto const& collider)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 1, 1 });
-            LOG_TRACE("ON TRIGGER EXIT");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
         };
         c.OnCollisionEnter +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 1, 0, 1 });
-            LOG_TRACE("ON COLLISION ENTER");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
         };
         c.OnCollisionStay +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 1, 1 });
-            LOG_TRACE("ON COLLISION STAY");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
         };
         c.OnCollisionExit +=
-            [=](auto const& manifolds)
+            [=](auto const& manifold)
         {
-            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 1, 1 });
-            LOG_TRACE("ON COLLISION EXIT");
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
+        };
+        //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
+        //m_other.AddComponent<engine::BoxCollider2D>();
+    }
+    
+    // Second Item : 1 kg Physics box
+    {
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "1 kg box";
+        m_other.Transform().Position().x = -m_initDiff;
+        m_other.Transform().Scale() = { 5.f, 5.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
+
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1.f);
+        pc.GravityScale = 0.0f;
+
+        m_other.AddComponent<engine::BoxCollider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
+        //c.IsTrigger = true;
+
+        c.OnTriggerEnter +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
+        };
+        c.OnTriggerStay +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
+        };
+        c.OnTriggerExit +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
+        };
+        c.OnCollisionEnter +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
+        };
+        c.OnCollisionStay +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
+        };
+        c.OnCollisionExit +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
         };
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
         //m_other.AddComponent<engine::BoxCollider2D>();
     }
 
+    // Third Item : 100 kg Physics circle
+    {
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "100kg circle";
+        m_other.Transform().Position().y = m_initDiff;
+        m_other.Transform().Scale() = { 20.f, 20.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
+
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(100.f);
+        pc.GravityScale = 0.0f;
+
+        m_other.AddComponent<engine::CircleCollider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
+        //c.IsTrigger = true;
+
+        c.OnTriggerEnter +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
+        };
+        c.OnTriggerStay +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
+        };
+        c.OnTriggerExit +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
+        };
+        c.OnCollisionEnter +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
+        };
+        c.OnCollisionStay +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
+        };
+        c.OnCollisionExit +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
+        };
+        //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
+        //m_other.AddComponent<engine::BoxCollider2D>();
+    }
+
+    // Fourth Item : 10 kg Physics circle
+    {
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "1 kg circle";
+        m_other.Transform().Position().y = -m_initDiff;
+        m_other.Transform().Scale() = { 5.f, 5.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
+
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1.f);
+        pc.GravityScale = 0.0f;
+
+        m_other.AddComponent<engine::CircleCollider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
+        //c.IsTrigger = true;
+
+        c.OnTriggerEnter +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
+        };
+        c.OnTriggerStay +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
+        };
+        c.OnTriggerExit +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
+        };
+        c.OnCollisionEnter +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
+        };
+        c.OnCollisionStay +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
+        };
+        c.OnCollisionExit +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
+        };
+        //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
+        //m_other.AddComponent<engine::BoxCollider2D>();
+    }
+
+
+    // Fifth Item : Trigger box
+    {
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "Trigger Box";
+        m_other.Transform().Position().x = m_other.Transform().Position().y = m_initDiff;
+        m_other.Transform().Scale() = { 50.f, 50.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
+
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(100.f);
+        pc.GravityScale = 0.0f;
+
+        m_other.AddComponent<engine::BoxCollider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
+        m_other.GetComponent<engine::Collider2D>().IsTrigger = true;
+
+        c.OnTriggerEnter +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
+        };
+        c.OnTriggerStay +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
+        };
+        c.OnTriggerExit +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
+        };
+        c.OnCollisionEnter +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
+        };
+        c.OnCollisionStay +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
+        };
+        c.OnCollisionExit +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
+        };
+        //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
+        //m_other.AddComponent<engine::BoxCollider2D>();
+    }
+
+    // Sixth Item : Trigger Circle
+    {
+        engine::GameObject m_other = CreateGameObject();
+        m_other.Name() = "Trigger Circle";
+        m_other.Transform().Position().x = m_other.Transform().Position().y = -m_initDiff;
+        m_other.Transform().Scale() = { 50.f, 50.f, 1.0f };
+        m_other.AddComponent<engine::ColliderDebugDraw>();
+
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1.f);
+        pc.GravityScale = 0.0f;
+
+        m_other.AddComponent<engine::CircleCollider2D>();
+        auto& c = m_other.GetComponent<engine::CollisionInfo>();
+        m_other.GetComponent<engine::Collider2D>().IsTrigger = true;
+
+        c.OnTriggerEnter +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
+            //LOG_TRACE("ON TRIGGER ENTER CONTROLLER");
+        };
+        c.OnTriggerStay +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
+            //LOG_TRACE("ON TRIGGER STAY CONTROLLER");
+        };
+        c.OnTriggerExit +=
+            [=](auto const& collider)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
+            //LOG_TRACE("ON TRIGGER EXIT CONTROLLER");
+        };
+        c.OnCollisionEnter +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION ENTER CONTROLLER");
+        };
+        c.OnCollisionStay +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
+            //LOG_TRACE("ON COLLISION STAY CONTROLLER");
+        };
+        c.OnCollisionExit +=
+            [=](auto const& manifold)
+        {
+            m_other.GetComponent<engine::ColliderDebugDraw>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
+            //LOG_TRACE("ON COLLISION EXIT CONTROLLER");
+        };
+        //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
+        //m_other.AddComponent<engine::BoxCollider2D>();
+    }
+
+
     ////Ground
     //{
     //    m_floor.Transform.Position() = { 0.f, -150.f, 0.f };
     //    m_floor.Transform.Scale() = { 1000.f, 5.f, 1.0f };
-    //    m_floor.AddComponent<engine::Sprite2D>();
+    //    m_floor.GetComponent<engine::ColliderDebugDraw>()();
     //    m_floor.AddComponent<engine::BoxCollider2D>();
     //    auto& pc = m_floor.AddComponent<engine::Rigidbody2D>();
     //    /*pc.SetMass(1.f);*/
@@ -164,13 +444,13 @@ void PhysicsTestLayer::OnUpdate(engine::Timestep dt)
     GetWorld()->GetSystem<engine::TransformSystem>()->Update();
     GetWorld()->GetSystem<engine::PhysicsSystem>()->Update(dt);
 
+    if(dt > 0.02) LOG_TRACE(dt);
+
     //reset
     if (engine::Input::IsKeyDown(ENGINE_KEY_R))
     {
         m_controller.Transform().Position() = m_spawnPosController;
         m_controller.GetComponent<engine::Rigidbody2D>().SetForce({ 0,0 });
-        m_other.Transform().Position() = m_spawnPosOther;
-        m_other.GetComponent<engine::Rigidbody2D>().SetForce({ 0,0 });
     }
 
     constexpr float force = 300.f;

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
@@ -34,25 +34,32 @@ void PhysicsTestLayer::Init()
         m_second = CreateGameObject();
         m_second.Transform().Scale() = { 50.f, 50.f, 1.0f };
         m_second.AddComponent<engine::Sprite2D>().SetTexture(tex);
-        auto& c = m_second.AddComponent<engine::Collider2D>();
-        //c.IsTrigger = true;
-        m_second.AddComponent<engine::CircleCollider2D>();
+        auto& pc = m_second.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1.f);
+        pc.GravityScale = 0.0f;
+        RootGameObject().AddChild(m_second);
+
+        m_second.AddComponent<engine::BoxCollider2D>();
+        auto& c = m_second.GetComponent<engine::Collider2D>();
+        c.IsTrigger = true;
+        
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
         //m_second.AddComponent<engine::BoxCollider2D>();
+
         c.OnTriggerEnter +=
-        [=](auto const& manifolds) 
+            [=](auto const& manifolds) 
         { 
             m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 0, 1 });
             LOG_TRACE("ON TRIGGER ENTER");
         };
         c.OnTriggerStay +=
-        [=](auto const& manifolds)
+            [=](auto const& manifolds)
         {
             m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 0, 1 });
             LOG_TRACE("ON TRIGGER STAY");
         };
         c.OnTriggerExit +=
-        [=](auto const& manifolds)
+            [=](auto const& manifolds)
         {
             m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 1, 1 });
             LOG_TRACE("ON TRIGGER EXIT");
@@ -76,11 +83,7 @@ void PhysicsTestLayer::Init()
             LOG_TRACE("ON COLLISION EXIT");
         };
 
-        auto& pc = m_second.AddComponent<engine::Rigidbody2D>();
         
-        pc.SetMass(1.f);
-        pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_second);
     }
 
     {
@@ -88,8 +91,15 @@ void PhysicsTestLayer::Init()
         m_third.Transform().Position() = { 100.f, 0.f, 0.f };
         m_third.Transform().Scale() = { 50.f, 50.f, 1.0f };
         m_third.AddComponent<engine::Sprite2D>().SetTexture(tex);
-        auto& c = m_third.AddComponent<engine::Collider2D>();
-        //c.IsTrigger = true;
+        
+        auto& pc = m_third.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1.f);
+        pc.GravityScale = 0.0f;
+        RootGameObject().AddChild(m_third);
+
+        m_third.AddComponent<engine::CircleCollider2D>();
+        auto& c = m_third.GetComponent<engine::Collider2D>();
+        c.IsTrigger = true;
         c.OnTriggerEnter +=
             [=](auto const& manifolds)
         {
@@ -126,13 +136,8 @@ void PhysicsTestLayer::Init()
             m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 1, 1 });
             LOG_TRACE("ON COLLISION EXIT");
         };
-        m_third.AddComponent<engine::CircleCollider2D>();
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
         //m_third.AddComponent<engine::BoxCollider2D>();
-        auto& pc = m_third.AddComponent<engine::Rigidbody2D>();
-        pc.SetMass(1.f);
-        pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_third);
     }
 
     ////Ground

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
@@ -15,10 +15,12 @@ Technology is prohibited.
 
 PhysicsTestLayer::PhysicsTestLayer()
     : SceneBaseLayer{ "PhysicsTestLayer" }
-    , upperbounds{ 500,  200 }
-    , lowerbounds{ -500, -200 }
-    , m_second{ }
-    , m_third{ }
+    , m_upperbounds{ 500,  200 }
+    , m_lowerbounds{ -500, -200 }
+    , m_spawnPosController { 0, 0, 0 }
+    , m_spawnPosOther { 75, 0, 0 }
+    , m_controller{ }
+    , m_other{ }
 {
 }
 
@@ -27,60 +29,62 @@ void PhysicsTestLayer::Init()
     auto ogreHandle = engine::AssetManager::ImportAsset("../Engine/assets/images/ogre.png");
     auto tex = engine::AssetManager::GetAsset<engine::Texture>(ogreHandle);
 
+    DefaultCamera().SetOrthographic(1000);
     auto& rs = GetWorld()->RegisterSystem<engine::Renderer2DSystem>(DefaultCamera());
     auto& ps = GetWorld()->RegisterSystem<engine::PhysicsSystem>();
 
     {
-        m_second = CreateGameObject();
-        m_second.Transform().Scale() = { 50.f, 50.f, 1.0f };
-        //m_second.AddComponent<engine::Sprite2D>().SetTexture(tex);
+        m_controller = CreateGameObject();
+        m_controller.Transform().Scale() = { 50.f, 50.f, 1.0f };
+        m_controller.Transform().Position() = m_spawnPosController;
+        m_controller.AddComponent<engine::Sprite2D>();
 
-        auto& pc = m_second.AddComponent<engine::Rigidbody2D>();
+        auto& pc = m_controller.AddComponent<engine::Rigidbody2D>();
         pc.SetMass(1.f);
         pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_second);
+        RootGameObject().AddChild(m_controller);
 
-        m_second.AddComponent<engine::BoxCollider2D>();
-        auto& c = m_second.GetComponent<engine::Collider2D>();
+        m_controller.AddComponent<engine::BoxCollider2D>();
+        auto& c = m_controller.GetComponent<engine::Collider2D>();
         //c.IsTrigger = true;
         
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
-        //m_second.AddComponent<engine::BoxCollider2D>();
+        //m_controller.AddComponent<engine::BoxCollider2D>();
 
         c.OnTriggerEnter +=
             [=](auto const& manifolds) 
         { 
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 0, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0, 1 });
             LOG_TRACE("ON TRIGGER ENTER");
         };
         c.OnTriggerStay +=
             [=](auto const& manifolds)
         {
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 0, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 0.5, 1 });
             LOG_TRACE("ON TRIGGER STAY");
         };
         c.OnTriggerExit +=
             [=](auto const& manifolds)
         {
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 1, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0.5, 0, 0, 1 });
             LOG_TRACE("ON TRIGGER EXIT");
         };
         c.OnCollisionEnter +=
             [=](auto const& manifolds)
         {
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 1, 0, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
             LOG_TRACE("ON COLLISION ENTER");
         };
         c.OnCollisionStay +=
             [=](auto const& manifolds)
         {
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 1, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0.5, 0.5, 0, 1 });
             LOG_TRACE("ON COLLISION STAY");
         };
         c.OnCollisionExit +=
             [=](auto const& manifolds)
         {
-            m_second.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 1, 1 });
+            m_controller.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0.5, 0.5, 1 });
             LOG_TRACE("ON COLLISION EXIT");
         };
 
@@ -88,57 +92,57 @@ void PhysicsTestLayer::Init()
     }
 
     {
-        m_third = CreateGameObject();
-        m_third.Transform().Position() = { -100.f, 0.f, 0.f };
-        m_third.Transform().Scale() = { 50.f, 50.f, 1.0f };
-        //m_third.AddComponent<engine::Sprite2D>();// .SetTexture(tex);
+        m_other = CreateGameObject();
+        m_other.Transform().Position() = m_spawnPosOther;
+        m_other.Transform().Scale() = { 50.f, 50.f, 1.0f };
+        m_other.AddComponent<engine::Sprite2D>();
         
-        auto& pc = m_third.AddComponent<engine::Rigidbody2D>();
-        pc.SetMass(1.f);
+        auto& pc = m_other.AddComponent<engine::Rigidbody2D>();
+        pc.SetMass(1000.f);
         pc.GravityScale = 0.0f;
-        RootGameObject().AddChild(m_third);
+        RootGameObject().AddChild(m_other);
 
-        m_third.AddComponent<engine::BoxCollider2D>();
-        auto& c = m_third.GetComponent<engine::Collider2D>();
+        m_other.AddComponent<engine::BoxCollider2D>();
+        auto& c = m_other.GetComponent<engine::Collider2D>();
         //c.IsTrigger = true;
         c.OnTriggerEnter +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 0, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 0, 1 });
             LOG_TRACE("ON TRIGGER ENTER");
         };
         c.OnTriggerStay +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 0, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 0, 1 });
             LOG_TRACE("ON TRIGGER STAY");
         };
         c.OnTriggerExit +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 1, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 0, 1, 1 });
             LOG_TRACE("ON TRIGGER EXIT");
         };
         c.OnCollisionEnter +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 1, 0, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 1, 0, 1 });
             LOG_TRACE("ON COLLISION ENTER");
         };
         c.OnCollisionStay +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 1, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 0, 1, 1, 1 });
             LOG_TRACE("ON COLLISION STAY");
         };
         c.OnCollisionExit +=
             [=](auto const& manifolds)
         {
-            m_third.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 1, 1 });
+            m_other.GetComponent<engine::Sprite2D>().SetColor(oom::vec4{ 1, 0, 1, 1 });
             LOG_TRACE("ON COLLISION EXIT");
         };
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
-        //m_third.AddComponent<engine::BoxCollider2D>();
+        //m_other.AddComponent<engine::BoxCollider2D>();
     }
 
     ////Ground
@@ -160,35 +164,46 @@ void PhysicsTestLayer::OnUpdate(engine::Timestep dt)
     GetWorld()->GetSystem<engine::TransformSystem>()->Update();
     GetWorld()->GetSystem<engine::PhysicsSystem>()->Update(dt);
 
+    //reset
+    if (engine::Input::IsKeyDown(ENGINE_KEY_R))
+    {
+        m_controller.Transform().Position() = m_spawnPosController;
+        m_controller.GetComponent<engine::Rigidbody2D>().SetForce({ 0,0 });
+        m_other.Transform().Position() = m_spawnPosOther;
+        m_other.GetComponent<engine::Rigidbody2D>().SetForce({ 0,0 });
+    }
+
     constexpr float force = 300.f;
     constexpr float jumpforce = 10000.f;
+    
+
 
     if (engine::Input::IsKeyHeld(ENGINE_KEY_UP))
     {
-        m_second.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, force });
+        m_controller.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, force });
     }
 
     if (engine::Input::IsKeyHeld(ENGINE_KEY_DOWN))
     {
-        m_second.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, -force });
+        m_controller.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, -force });
     }
 
     if (engine::Input::IsKeyHeld(ENGINE_KEY_RIGHT))
     {
-        m_second.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ force, 0 });
+        m_controller.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ force, 0 });
     }
 
     if (engine::Input::IsKeyHeld(ENGINE_KEY_LEFT))
     {
-        m_second.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ -force, 0 });
+        m_controller.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ -force, 0 });
     }
 
     if (engine::Input::IsKeyPressed(ENGINE_KEY_SPACE))
     {
-        m_second.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, jumpforce });
+        m_controller.GetComponent<engine::Rigidbody2D>().ApplyForce(oom::vec2{ 0, jumpforce });
     }
 
-    /*auto rootsForce = m_second.GetComponent<engine::Rigidbody2D>().GetForce();
+    /*auto rootsForce = m_controller.GetComponent<engine::Rigidbody2D>().GetForce();
     LOG_TRACE("{0}{1}", rootsForce.x, rootsForce.y );*/
 
     // transform objects
@@ -196,21 +211,21 @@ void PhysicsTestLayer::OnUpdate(engine::Timestep dt)
     for (auto [transform] : view)
     {
         //auto& transform = GetWorld()->GetComponent<engine::Transform3D>(ent);
-        if (transform.Position().y < lowerbounds.y)
+        if (transform.Position().y < m_lowerbounds.y)
         {
-            transform.Position().y = upperbounds.y;
+            transform.Position().y = m_upperbounds.y;
         }
-        if (transform.Position().y > upperbounds.y)
+        if (transform.Position().y > m_upperbounds.y)
         {
-            transform.Position().y = lowerbounds.y;
+            transform.Position().y = m_lowerbounds.y;
         }
-        if (transform.Position().x < lowerbounds.x)
+        if (transform.Position().x < m_lowerbounds.x)
         {
-            transform.Position().x = upperbounds.x;
+            transform.Position().x = m_upperbounds.x;
         }
-        if (transform.Position().x > upperbounds.x)
+        if (transform.Position().x > m_upperbounds.x)
         {
-            transform.Position().x = lowerbounds.x;
+            transform.Position().x = m_lowerbounds.x;
         }
 
     }

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
@@ -447,7 +447,7 @@ void PhysicsTestLayer::OnUpdate(engine::Timestep dt)
     if(dt > 0.02) LOG_TRACE(dt);
 
     //reset
-    if (engine::Input::IsKeyDown(ENGINE_KEY_R))
+    if (engine::Input::IsKeyPressed(ENGINE_KEY_R))
     {
         m_controller.Transform().Position() = m_spawnPosController;
         m_controller.GetComponent<engine::Rigidbody2D>().SetForce({ 0,0 });

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.cpp
@@ -33,7 +33,8 @@ void PhysicsTestLayer::Init()
     {
         m_second = CreateGameObject();
         m_second.Transform().Scale() = { 50.f, 50.f, 1.0f };
-        m_second.AddComponent<engine::Sprite2D>().SetTexture(tex);
+        //m_second.AddComponent<engine::Sprite2D>().SetTexture(tex);
+
         auto& pc = m_second.AddComponent<engine::Rigidbody2D>();
         pc.SetMass(1.f);
         pc.GravityScale = 0.0f;
@@ -41,7 +42,7 @@ void PhysicsTestLayer::Init()
 
         m_second.AddComponent<engine::BoxCollider2D>();
         auto& c = m_second.GetComponent<engine::Collider2D>();
-        c.IsTrigger = true;
+        //c.IsTrigger = true;
         
         //c.SetNarrowPhaseCollider(engine::ColliderType::BOX);
         //m_second.AddComponent<engine::BoxCollider2D>();
@@ -88,18 +89,18 @@ void PhysicsTestLayer::Init()
 
     {
         m_third = CreateGameObject();
-        m_third.Transform().Position() = { 100.f, 0.f, 0.f };
+        m_third.Transform().Position() = { -100.f, 0.f, 0.f };
         m_third.Transform().Scale() = { 50.f, 50.f, 1.0f };
-        m_third.AddComponent<engine::Sprite2D>().SetTexture(tex);
+        //m_third.AddComponent<engine::Sprite2D>();// .SetTexture(tex);
         
         auto& pc = m_third.AddComponent<engine::Rigidbody2D>();
         pc.SetMass(1.f);
         pc.GravityScale = 0.0f;
         RootGameObject().AddChild(m_third);
 
-        m_third.AddComponent<engine::CircleCollider2D>();
+        m_third.AddComponent<engine::BoxCollider2D>();
         auto& c = m_third.GetComponent<engine::Collider2D>();
-        c.IsTrigger = true;
+        //c.IsTrigger = true;
         c.OnTriggerEnter +=
             [=](auto const& manifolds)
         {

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.h
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.h
@@ -19,11 +19,12 @@ class PhysicsTestLayer : public SceneBaseLayer
 {
 private:
     int width{}, height{};
-    engine::GameObject m_controller, m_other;
+    engine::GameObject m_controller;
 
     oom::vec2 m_upperbounds, m_lowerbounds;
 
-    oom::vec3 m_spawnPosController, m_spawnPosOther;
+    oom::vec3 m_spawnPosController;
+    float m_initDiff;
 
 public:
 

--- a/Sandbox/src/TestLayers/PhysicsTestLayer.h
+++ b/Sandbox/src/TestLayers/PhysicsTestLayer.h
@@ -19,9 +19,11 @@ class PhysicsTestLayer : public SceneBaseLayer
 {
 private:
     int width{}, height{};
-    engine::GameObject m_second, m_third;
+    engine::GameObject m_controller, m_other;
 
-    oom::vec2 upperbounds, lowerbounds;
+    oom::vec2 m_upperbounds, m_lowerbounds;
+
+    oom::vec3 m_spawnPosController, m_spawnPosOther;
 
 public:
 


### PR DESCRIPTION
Updated Physics to not need to add collider2D component manually nor set anymore
Added physics interactions for box and circle
Updated Physics Test Layers
Physics between box and circle now works entirely!
Update to IsKeyPressed
Physics system now supports :
- All Combinations of Collision/Triggers between all combinations of Box/Circle with its appropriate Physics-based response and trigger responses
- Callbacks now are on a per object basis
- Dynamically Changing Triggers results in appropriate callbacks

Physics will not support :
- Multiple colliders (attempting to add another collider in real-time will result swapping of colliders)
- Dynamic Collider Changes in Objects (you can do this, but expect possible UDB)